### PR TITLE
Force tests to use EN locale of Google search

### DIFF
--- a/iris/tests/experiments/back_forward.py
+++ b/iris/tests/experiments/back_forward.py
@@ -22,7 +22,7 @@ class test(base_test):
         navigate(url)
 
         if exists("search_the_web.png", 10):
-            url = "www.google.com"
+            url = "https://www.google.com/?hl=EN"
 
             # helper function from "keyboard_shortcuts"
             navigate(url)

--- a/iris/tests/experiments/basic_url.py
+++ b/iris/tests/experiments/basic_url.py
@@ -18,7 +18,7 @@ class test(base_test):
 
     def run(self):
 
-        url = "www.google.com"
+        url = "https://www.google.com/?hl=EN"
         # helper function from "awesome_bar"
         navigate(url)
 

--- a/iris/tests/experiments/tabs.py
+++ b/iris/tests/experiments/tabs.py
@@ -31,7 +31,7 @@ class test(base_test):
         new_tab()
 
         # helper function
-        navigate("google.com")
+        navigate("https://www.google.com/?hl=EN")
 
         # core api function
         if exists("google_search.png", 15):


### PR DESCRIPTION
These tests need to use a URL with an English locale, because the images are taken from an English language Google web page.