### PR TITLE
Removed extra call to maximize_window

### DIFF
--- a/iris/tests/experiments/customize_new_tab.py
+++ b/iris/tests/experiments/customize_new_tab.py
@@ -17,7 +17,6 @@ class test(base_test):
 
     def run(self):
 
-        maximize_window()
         url = "about:home"
         customize_new_tab_page_image = "customize_new_tab_icon.png"
         tab_preference_search_button = "tab_preference_search_button.png"


### PR DESCRIPTION
Now that we launch every test case with a maximized window, by default, individual test cases don't need to do this. 

This test case had an explicit call to maximize the window, which - combined with our changes above - was causing it to fail on Windows. The mouse ended up on top of some UI, causing a tooltip to appear, blocking the home icon.  The home icon is a crucial piece of UI that we use to verify Firefox has been launched. 