### PR TITLE
Revert "Manage temp screenshot files"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ local/
 *.sh.swp
 config.ini
 *.ini
-.temp.png
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/iris/__main__.py
+++ b/iris/__main__.py
@@ -609,11 +609,6 @@ class RemoveTempDir(cleanup.CleanUp):
             logger.debug('Removing temp dir "%s"' % tmp_dir)
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
-        tmp_png = os.path.join(IrisCore.get_module_dir(), '.temp.png')
-        if os.path.isfile(tmp_png):
-            logger.debug('Removing .temp.png in module directory.')
-            os.remove(tmp_png)
-
 
 class ResetTerminalEncoding(cleanup.CleanUp):
     """Class for restoring original terminal encoding at exit."""

--- a/iris/api/core/platform.py
+++ b/iris/api/core/platform.py
@@ -3,8 +3,8 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import mozinfo
-import os
 import pyautogui
+
 
 class Platform(object):
     """Class that holds all supported operating systems (HIGH_DEF = High definition displays)."""
@@ -17,7 +17,6 @@ class Platform(object):
     PROCESSOR = mozinfo.processor
 
     ALL = [LINUX, MAC, WINDOWS]
-    tmp_file_path = os.path.join(os.path.realpath(os.path.split(__file__)[0] + '/../../..'), '.temp.png')
-    HIGH_DEF = not (pyautogui.screenshot(tmp_file_path).size == pyautogui.size())
+    HIGH_DEF = not (pyautogui.screenshot().size == pyautogui.size())
     SCREEN_WIDTH, SCREEN_HEIGHT = pyautogui.size()
     LOW_RES = (SCREEN_WIDTH < 1280 or SCREEN_HEIGHT < 800)

--- a/iris/api/core/util/core_helper.py
+++ b/iris/api/core/util/core_helper.py
@@ -18,8 +18,7 @@ from parse_args import parse_args
 from version_parser import check_version
 
 SCREEN_WIDTH, SCREEN_HEIGHT = pyautogui.size()
-tmp_file_path = os.path.join(os.path.realpath(os.path.split(__file__)[0] + '/../../../..'), '.temp.png')
-SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT = pyautogui.screenshot(tmp_file_path).size
+SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT = pyautogui.screenshot().size
 
 SUCCESS_LEVEL_NUM = 35
 logging.addLevelName(SUCCESS_LEVEL_NUM, 'SUCCESS')
@@ -207,20 +206,20 @@ class IrisCore(object):
         :return: Image
         """
         is_uhd, uhd_factor = IrisCore.get_uhd_details()
-        tmp_img_path = os.path.join(IrisCore.get_module_dir(), '.temp.png')
 
         if region is not None:
             r_x = uhd_factor * region.x if is_uhd else region.x
             r_y = uhd_factor * region.y if is_uhd else region.y
             r_w = uhd_factor * region.width if is_uhd else region.width
             r_h = uhd_factor * region.height if is_uhd else region.height
-            grabbed_area = pyautogui.screenshot(tmp_img_path, region=(r_x, r_y, r_w, r_h))
+
+            grabbed_area = pyautogui.screenshot(region=(r_x, r_y, r_w, r_h))
 
             if is_uhd and not for_ocr:
                 grabbed_area = grabbed_area.resize([region.width, region.height])
             return grabbed_area
 
-        grabbed_area = pyautogui.screenshot(tmp_img_path, region=(0, 0, SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT))
+        grabbed_area = pyautogui.screenshot(region=(0, 0, SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT))
 
         if is_uhd and not for_ocr:
             return grabbed_area.resize([SCREEN_WIDTH, SCREEN_HEIGHT])


### PR DESCRIPTION
Reverts mozilla/iris#1271

Causes some regressions with image libraries that Iris uses.