### PR TITLE
Add support for more locales

### DIFF
--- a/iris/api/core/settings.py
+++ b/iris/api/core/settings.py
@@ -32,7 +32,8 @@ DEFAULT_HEAVY_SITE_LOAD_TIMEOUT = 90
 
 
 CHANNELS = ('beta', 'release', 'nightly', 'esr', 'dev')
-LOCALES = ('en-US', 'zh-CN', 'es-ES', 'de', 'fr', 'ru', 'ar', 'ko', 'pt-PT', 'vi', 'pl', 'tr', 'ro', 'ja')
+LOCALES = ('en-US', 'zh-CN', 'es-ES', 'de', 'fr', 'ru', 'ar', 'ko', 'pt-PT', 'vi',
+           'pl', 'tr', 'ro', 'ja' ,'it', 'pt-BR', 'in', 'en-GB', 'id', 'ca')
 
 
 class _IrisSettings(object):


### PR DESCRIPTION
Fixes #1936. When an Iris user specifies a locale with the `-l` flag, we use that locale in the pattern lookup logic. 

E.g.
`iris -t test_name -l ca`

When searching for patterns inside the `images` folder, we'll first search subfolders that start with `ca`.


All I did here was add six new locales to the data used by the Control Center. One of the requested locales was already present.