### PR TITLE
Issue 1991

### DIFF
--- a/iris/tests/plugin_compatibility/cnn_heavy_content.py
+++ b/iris/tests/plugin_compatibility/cnn_heavy_content.py
@@ -18,6 +18,8 @@ class Test(BaseTest):
         related_video_pattern = Pattern('related_video.png')
         share_button_pattern = Pattern('share_button.png')
 
+        change_preference('media.autoplay.default', '0')
+
         new_private_window()
 
         private_window_opened = exists(new_private_browsing_tab_pattern, 20)
@@ -59,3 +61,5 @@ class Test(BaseTest):
 
         related_video_playing = exists(speaker_icon_pattern, 100)
         assert_true(self, related_video_playing, 'The video is playing and there is no browser crashes')
+
+        close_window()

--- a/iris/tests/plugin_compatibility/nasa_tv_heavy_content.py
+++ b/iris/tests/plugin_compatibility/nasa_tv_heavy_content.py
@@ -19,6 +19,8 @@ class Test(BaseTest):
         media_button_pattern = Pattern('media_button.png')
         video_drop_down_pattern = Pattern('video_drop_down.png')
 
+        change_preference('media.autoplay.default', '0')
+
         new_private_window()
 
         private_window_opened = exists(new_private_browsing_tab_pattern, DEFAULT_FIREFOX_TIMEOUT)


### PR DESCRIPTION
Fixing issues affected by Firefox 66.0b3 update that blocked autoplay media with sound.
"change_preference('media.autoplay.default', '0')" added
Affected tests:

cnn_heavy_content #1596
nasa_tv_heavy_content #1595