### PR TITLE
[issue_2234] Downgrade OpenCV library for Windows 7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ iris = {path = ".",editable = true}
 pyautogui = "==0.9.41"
 coloredlogs = "==10.0"
 python-dateutil = "==2.8.0"
-opencv-python = "==4.0.0.21"
+opencv-python = "==3.4.1.15"  #version needed for Windows 7
 pytesseract = "==0.2.6"
 numpy = "==1.16.1"
 image = "==1.5.27"


### PR DESCRIPTION
This is for https://github.com/mozilla/iris/issues/2234
Need to downgrade OpenCV library because of errors on Wondows 7